### PR TITLE
#44 Updated provider versions

### DIFF
--- a/modules/terrahome_azure/main.tf
+++ b/modules/terrahome_azure/main.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     azurerm = {
       source = "hashicorp/azurerm"
-      version = "3.76.0"
+      version = "~>3.82.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~>3.0"
+      version = "~>3.5.1"
     }
   }
 }


### PR DESCRIPTION
Updated provider versions to the current as of date 27th November 2023.

After : -
tf init -upgrade
tf destroy  # did not return Error: Unable to locate Storage Account this time